### PR TITLE
Simple Errors

### DIFF
--- a/NetworkStack/AuthRequests.swift
+++ b/NetworkStack/AuthRequests.swift
@@ -10,8 +10,8 @@ import Foundation
 import Marshal
 
 public protocol AuthRequests {
-    func authenticate(username: String, password: String, completion: Network.ResponseCompletion) throws
-    func authenticate(pairingCode: String, completion: Network.ResponseCompletion) throws
+    func authenticate(username: String, password: String, completion: Network.ResponseCompletion)
+    func authenticate(pairingCode: String, completion: Network.ResponseCompletion)
     func authenticate(tokenJSON: JSONObject) throws
     func logOut()
 }
@@ -31,9 +31,13 @@ public struct AuthAPIRequests: AuthRequests {
     // MARK: - Public API
     
     /// - Precondition: `AppNetworkState.currentAppState` must not be nil
-    public func authenticate(username: String, password: String, completion: Network.ResponseCompletion) throws {
+    public func authenticate(username: String, password: String, completion: Network.ResponseCompletion) {
         guard let appNetworkState = AppNetworkState.currentAppState else { fatalError("Must configure current app state to log in") }
-        guard let url = NSURL(string: appNetworkState.tokenEndpointURLString) else { throw Network.Error.MalformedEndpoint(endpoint: appNetworkState.tokenEndpointURLString) }
+        guard let url = NSURL(string: appNetworkState.tokenEndpointURLString) else {
+            let error = Network.Error.MalformedEndpoint(endpoint: appNetworkState.tokenEndpointURLString)
+            completion(.Error(error))
+            return
+        }
         let parameters = [
             "grant_type": "password",
             "username": username,
@@ -60,10 +64,14 @@ public struct AuthAPIRequests: AuthRequests {
     }
     
     /// - Precondition: `AppNetworkState.currentAppState` must not be nil
-    public func authenticate(pairingCode: String, completion: Network.ResponseCompletion) throws {
+    public func authenticate(pairingCode: String, completion: Network.ResponseCompletion) {
         guard let deviceUUID = UIDevice.currentDevice().identifierForVendor else { fatalError("Device must have an identifier to log in") }
         guard let appNetworkState = AppNetworkState.currentAppState else { fatalError("Must configure current app state to log in") }
-        guard let url = NSURL(string: appNetworkState.tokenEndpointURLString) else { throw Network.Error.MalformedEndpoint(endpoint: appNetworkState.tokenEndpointURLString) }
+        guard let url = NSURL(string: appNetworkState.tokenEndpointURLString) else {
+            let error = Network.Error.MalformedEndpoint(endpoint: appNetworkState.tokenEndpointURLString)
+            completion(.Error(error))
+            return
+        }
         let parameters = [
             "client_id": pairingCode,
             "grant_type": "device",

--- a/NetworkStack/NetworkRequests.swift
+++ b/NetworkStack/NetworkRequests.swift
@@ -10,11 +10,11 @@ import Foundation
 import Marshal
 
 public protocol NetworkRequests {
-    func get(endpoint: String, parameters: JSONObject?, completion: Network.ResponseCompletion) throws
-    func post(endpoint: String, parameters: JSONObject?, completion: Network.ResponseCompletion) throws
-    func patch(endpoint: String, parameters: JSONObject?, completion: Network.ResponseCompletion) throws
-    func put(endpoint: String, parameters: JSONObject?, completion: Network.ResponseCompletion) throws
-    func delete(endpoint: String, completion: Network.ResponseCompletion) throws
+    func get(endpoint: String, parameters: JSONObject?, completion: Network.ResponseCompletion)
+    func post(endpoint: String, parameters: JSONObject?, completion: Network.ResponseCompletion)
+    func patch(endpoint: String, parameters: JSONObject?, completion: Network.ResponseCompletion)
+    func put(endpoint: String, parameters: JSONObject?, completion: Network.ResponseCompletion)
+    func delete(endpoint: String, completion: Network.ResponseCompletion)
 }
 
 public struct NetworkAPIRequests: NetworkRequests {
@@ -43,29 +43,55 @@ public struct NetworkAPIRequests: NetworkRequests {
     
     // MARK: - Public API
     
-    public func get(endpoint: String, parameters: JSONObject?, completion: Network.ResponseCompletion) throws {
-        let (session, url) = try config(endpoint)
-        network.get(url, session: session, parameters: parameters, completion: completion)
+    public func get(endpoint: String, parameters: JSONObject?, completion: Network.ResponseCompletion) {
+        do {
+            let (session, url) = try config(endpoint)
+            network.get(url, session: session, parameters: parameters, completion: completion)
+        }
+        catch {
+            completion(.Error(error))
+        }
     }
     
-    public func post(endpoint: String, parameters: JSONObject?, completion: Network.ResponseCompletion) throws {
-        let (session, url) = try config(endpoint)
-        network.post(url, session: session, parameters: parameters, completion: completion)
+    public func post(endpoint: String, parameters: JSONObject?, completion: Network.ResponseCompletion) {
+        do {
+            let (session, url) = try config(endpoint)
+            network.post(url, session: session, parameters: parameters, completion: completion)
+        }
+        catch {
+            completion(.Error(error))
+        }
     }
     
-    public func patch(endpoint: String, parameters: JSONObject?, completion: Network.ResponseCompletion) throws {
-        let (session, url) = try config(endpoint)
-        network.patch(url, session: session, parameters: parameters, completion: completion)
+    public func patch(endpoint: String, parameters: JSONObject?, completion: Network.ResponseCompletion) {
+        do {
+            let (session, url) = try config(endpoint)
+            network.patch(url, session: session, parameters: parameters, completion: completion)
+        }
+        catch {
+            completion(.Error(error))
+        }
     }
     
-    public func put(endpoint: String, parameters: JSONObject?, completion: Network.ResponseCompletion) throws {
-        let (session, url) = try config(endpoint)
-        network.put(url, session: session, parameters: parameters, completion: completion)
+    public func put(endpoint: String, parameters: JSONObject?, completion: Network.ResponseCompletion) {
+        do {
+            let (session, url) = try config(endpoint)
+            network.put(url, session: session, parameters: parameters, completion: completion)
+        }
+        catch {
+            completion(.Error(error))
+        }
     }
     
-    public func delete(endpoint: String, completion: Network.ResponseCompletion) throws {
-        let (session, url) = try config(endpoint)
-        network.delete(url, session: session, completion: completion)
+    public func delete(endpoint: String, completion: Network.ResponseCompletion) {
+        do {
+            let (session, url) = try config(endpoint)
+            network.delete(url, session: session, completion: completion)
+        }
+            
+        catch {
+            completion(.Error(error))
+        }
     }
     
 }


### PR DESCRIPTION
Makes sure anything that has a completion callback does not also `throw`. Just passes error back through completion instead.