### PR TITLE
Added EndpointType

### DIFF
--- a/NetworkStack/NetworkRequests.swift
+++ b/NetworkStack/NetworkRequests.swift
@@ -9,15 +9,24 @@
 import Foundation
 import Marshal
 
+
+/// Declare a struct that conforms to this protocol in your project with a
+/// private initializer and static let/funcs to have a centralized place
+/// for declarations of API endpoints.
+public protocol EndpointType {
+    var value: String { get }
+}
+
+
 public protocol NetworkRequests {
-    func get(from endpoint: String, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion)
-    func hyperGet(from endpoint: String, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion)
+    func get(from endpoint: EndpointType, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion)
+    func hyperGet(from endpoint: EndpointType, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion)
     func get(from components: NSURLComponents, completion: @escaping Network.ResponseCompletion)
-    func post(to endpoint: String, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion)
-    func post(to endpoint: String, with parameters: JSONObject?, timeoutLength: TimeInterval?, completion: @escaping Network.ResponseCompletion)
-    func patch(to endpoint: String, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion)
-    func put(to endpoint: String, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion)
-    func delete(at endpoint: String, completion: @escaping Network.ResponseCompletion)
+    func post(to endpoint: EndpointType, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion)
+    func post(to endpoint: EndpointType, with parameters: JSONObject?, timeoutLength: TimeInterval?, completion: @escaping Network.ResponseCompletion)
+    func patch(to endpoint: EndpointType, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion)
+    func put(to endpoint: EndpointType, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion)
+    func delete(at endpoint: EndpointType, completion: @escaping Network.ResponseCompletion)
 }
 
 public struct NetworkAPIRequests: NetworkRequests {
@@ -61,19 +70,19 @@ public struct NetworkAPIRequests: NetworkRequests {
 
     // MARK: - Public API
 
-    public func get(from endpoint: String, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion) {
+    public func get(from endpoint: EndpointType, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion) {
         do {
-            let (session, url) = try config(endpoint: endpoint)
+            let (session, url) = try config(endpoint: endpoint.value)
             network.get(from: url, using: session, with: parameters, completion: completion)
         }
         catch {
             completion(.error(error), nil)
         }
     }
-
-    public func hyperGet(from endpoint: String, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion) {
+    
+    public func hyperGet(from endpoint: EndpointType, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion) {
         do {
-            let result = try self.config(endpoint: endpoint)
+            let result = try self.config(endpoint: endpoint.value)
             var session = result.session
             let config = result.session.configuration
             if var headers = config.httpAdditionalHeaders {
@@ -100,20 +109,20 @@ public struct NetworkAPIRequests: NetworkRequests {
             completion(.error(error), nil)
         }
     }
-
-    public func post(to endpoint: String, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion) {
+    
+    public func post(to endpoint: EndpointType, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion) {
         do {
-            let (session, url) = try config(endpoint: endpoint)
+            let (session, url) = try config(endpoint: endpoint.value)
             network.post(to: url, using: session, with: parameters, completion: completion)
         }
         catch {
             completion(.error(error), nil)
         }
     }
-
-    public func post(to endpoint: String, with parameters: JSONObject?, timeoutLength: TimeInterval? = nil, completion: @escaping Network.ResponseCompletion) {
+    
+    public func post(to endpoint: EndpointType, with parameters: JSONObject?, timeoutLength: TimeInterval? = nil, completion: @escaping Network.ResponseCompletion) {
         do {
-            let (session, url) = try config(endpoint: endpoint)
+            let (session, url) = try config(endpoint: endpoint.value)
             if let timeoutLength = timeoutLength {
                 session.configuration.timeoutIntervalForRequest = timeoutLength
             }
@@ -124,9 +133,9 @@ public struct NetworkAPIRequests: NetworkRequests {
         }
     }
 
-    public func patch(to endpoint: String, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion) {
+    public func patch(to endpoint: EndpointType, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion) {
         do {
-            let (session, url) = try config(endpoint: endpoint)
+            let (session, url) = try config(endpoint: endpoint.value)
             network.patch(to: url, using: session, with: parameters, completion: completion)
         }
         catch {
@@ -134,9 +143,9 @@ public struct NetworkAPIRequests: NetworkRequests {
         }
     }
 
-    public func put(to endpoint: String, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion) {
+    public func put(to endpoint: EndpointType, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion) {
         do {
-            let (session, url) = try config(endpoint: endpoint)
+            let (session, url) = try config(endpoint: endpoint.value)
             network.put(to: url, using: session, with: parameters, completion: completion)
         }
         catch {
@@ -144,9 +153,9 @@ public struct NetworkAPIRequests: NetworkRequests {
         }
     }
 
-    public func delete(at endpoint: String, completion: @escaping Network.ResponseCompletion) {
+    public func delete(at endpoint: EndpointType, completion: @escaping Network.ResponseCompletion) {
         do {
-            let (session, url) = try config(endpoint: endpoint)
+            let (session, url) = try config(endpoint: endpoint.value)
             network.delete(at: url, using: session, completion: completion)
         }
 

--- a/NetworkStack/NetworkRequests.swift
+++ b/NetworkStack/NetworkRequests.swift
@@ -72,7 +72,7 @@ public struct NetworkAPIRequests: NetworkRequests {
 
     public func get(from endpoint: EndpointType, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion) {
         do {
-            let (session, url) = try config(endpoint: endpoint.value)
+            let (session, url) = try config(endpoint: endpoint)
             network.get(from: url, using: session, with: parameters, completion: completion)
         }
         catch {
@@ -82,7 +82,7 @@ public struct NetworkAPIRequests: NetworkRequests {
     
     public func hyperGet(from endpoint: EndpointType, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion) {
         do {
-            let result = try self.config(endpoint: endpoint.value)
+            let result = try self.config(endpoint: endpoint)
             var session = result.session
             let config = result.session.configuration
             if var headers = config.httpAdditionalHeaders {
@@ -111,18 +111,12 @@ public struct NetworkAPIRequests: NetworkRequests {
     }
     
     public func post(to endpoint: EndpointType, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion) {
-        do {
-            let (session, url) = try config(endpoint: endpoint.value)
-            network.post(to: url, using: session, with: parameters, completion: completion)
-        }
-        catch {
-            completion(.error(error), nil)
-        }
+        post(to: endpoint, with: parameters, timeoutLength: nil, completion: completion)
     }
     
     public func post(to endpoint: EndpointType, with parameters: JSONObject?, timeoutLength: TimeInterval? = nil, completion: @escaping Network.ResponseCompletion) {
         do {
-            let (session, url) = try config(endpoint: endpoint.value)
+            let (session, url) = try config(endpoint: endpoint)
             if let timeoutLength = timeoutLength {
                 session.configuration.timeoutIntervalForRequest = timeoutLength
             }
@@ -135,7 +129,7 @@ public struct NetworkAPIRequests: NetworkRequests {
 
     public func patch(to endpoint: EndpointType, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion) {
         do {
-            let (session, url) = try config(endpoint: endpoint.value)
+            let (session, url) = try config(endpoint: endpoint)
             network.patch(to: url, using: session, with: parameters, completion: completion)
         }
         catch {
@@ -145,7 +139,7 @@ public struct NetworkAPIRequests: NetworkRequests {
 
     public func put(to endpoint: EndpointType, with parameters: JSONObject?, completion: @escaping Network.ResponseCompletion) {
         do {
-            let (session, url) = try config(endpoint: endpoint.value)
+            let (session, url) = try config(endpoint: endpoint)
             network.put(to: url, using: session, with: parameters, completion: completion)
         }
         catch {
@@ -155,7 +149,7 @@ public struct NetworkAPIRequests: NetworkRequests {
 
     public func delete(at endpoint: EndpointType, completion: @escaping Network.ResponseCompletion) {
         do {
-            let (session, url) = try config(endpoint: endpoint.value)
+            let (session, url) = try config(endpoint: endpoint)
             network.delete(at: url, using: session, completion: completion)
         }
 
@@ -166,6 +160,11 @@ public struct NetworkAPIRequests: NetworkRequests {
 
 
     // MARK: - Private functions
+
+    /// - Precondition: `AppNetworkState.currentAppState` must not be nil
+    private func config(endpoint: EndpointType) throws -> (session: URLSession, url: URL) {
+        return try config(endpoint: endpoint.value)
+    }
 
     /// - Precondition: `AppNetworkState.currentAppState` must not be nil
     private func config(endpoint: String) throws -> (session: URLSession, url: URL) {


### PR DESCRIPTION
This allows us to make sure nobody calls `get` or `post` with magic strings. Instead the projects should declare a type that conforms to EndpointType with a private initializer and static let/funcs to hold all endpoints.

# Conflicts:
#	NetworkStack/NetworkRequests.swift